### PR TITLE
Small changes to clean up S3 support

### DIFF
--- a/App/main.cpp
+++ b/App/main.cpp
@@ -18,6 +18,8 @@ void outputLogo() {
 
 int main(int ac, const char* av[]) {
     dg::deepcore::log::init();
+    auto tempSink = dg::deepcore::log::addClogSink(dg::deepcore::level_t::error, dg::deepcore::level_t::fatal,
+                                                   dg::deepcore::log::dg_log_format::dg_short_log);
 
     outputLogo();
     namespace po = boost::program_options;
@@ -141,6 +143,7 @@ int main(int ac, const char* av[]) {
         args.outputFormat = vm["format"].as<string>();
     } else {
         cout << "Output format was not set. Forcing to shp.\n";
+        args.outputFormat = "shp";
     }
 
     //TODO: make this smarter wrt format.  If the output format is ES, then the default doesn't work.

--- a/App/src/libopenskynet.cpp
+++ b/App/src/libopenskynet.cpp
@@ -257,11 +257,6 @@ int addFeature(VectorFeatureSet& fs, const GdalImage& image, const cv::Rect& win
 }
 
 int classifyFromFile(OpenSkyNetArgs &args) {
-    if(!boost::filesystem::is_regular_file(args.image)) {
-        std::cerr << args.image << "does not exist." << std::endl;
-        return INVALID_URL;
-    }
-
     cout << "Reading image..." << endl;
     GdalImage gdalImage(args.image);
 


### PR DESCRIPTION
Resolves DigitalGlobe/DeepCore#31 by disabling the file check.  A wiki entry on S3 usage was also added to https://github.com/DigitalGlobe/OPENSKYNET/wiki/Using-S3-Images-with-OpenSkyNet.
