### PR TITLE
If the BUILD_NUMBER environment variable is not defined, the default …

### DIFF
--- a/App/CMakeLists.txt
+++ b/App/CMakeLists.txt
@@ -16,7 +16,7 @@ set(OpenSkyNet_VERSION_MINOR 1)
 if(DEFINED ENV{BUILD_NUMBER})
     set(OpenSkyNet_VERSION_BUILD $ENV{BUILD_NUMBER})
 else()
-    set(OpenSkyNet_VERSION_BUILD 0)
+    set(OpenSkyNet_VERSION_BUILD "SNAPSHOT")
 endif()
 
 # Initialize version.h


### PR DESCRIPTION
…build number will now be SNAPSHOT
