### PR TITLE
Fix for validation seeing default values as user input

### DIFF
--- a/src/OpenSkyNetArgs.cpp
+++ b/src/OpenSkyNetArgs.cpp
@@ -35,6 +35,7 @@
 #include <imagery/cv_program_options.hpp>
 #include <iomanip>
 #include <utility/Console.h>
+#include <utility/program_options.hpp>
 #include <vector/FeatureSet.h>
 
 namespace dg { namespace osn {
@@ -44,6 +45,7 @@ namespace po = boost::program_options;
 using namespace deepcore;
 
 using boost::program_options::variables_map;
+using boost::program_options::name_with_default;
 using dg::deepcore::level_t;
 using boost::adaptors::reverse;
 using boost::filesystem::path;
@@ -85,14 +87,6 @@ static const string OSN_LANDCOVER_USAGE =
         "Usage:\n"
         "  OpenSkyNet landcover <input options> <output options> <processing options>\n\n";
 
-template<class T>
-static string NameWithDefault(string name, T defaultVal) {
-    std::ostringstream string;
-    string << name;
-    string << " (=" << defaultVal << ")";
-    return string.str();
-}
-
 OpenSkyNetArgs::OpenSkyNetArgs() :
     localOptions_("Local Image Input Options"),
     webOptions_("Web Service Input Options"),
@@ -116,9 +110,9 @@ OpenSkyNetArgs::OpenSkyNetArgs() :
         ("credentials", po::value<string>()->value_name("USERNAME[:PASSWORD]"),
          "Credentials for the map service. Not required for Web Maps API. If password is not specified, you will be "
          "prompted to enter it. The credentials can also be set by setting the OSN_CREDENTIALS environment variable.")
-        ("zoom", po::value<int>()->value_name(NameWithDefault("ZOOM", zoom)), "Zoom level.")
-        ("mapId", po::value<string>()->value_name(NameWithDefault("MAPID", MAPSAPI_MAPID)), "MapsAPI map id to use.")
-        ("num-downloads", po::value<int>()->default_value(maxConnections)->value_name("NUM"),
+        ("zoom", po::value<int>()->value_name(name_with_default("ZOOM", zoom)), "Zoom level.")
+        ("mapId", po::value<string>()->value_name(name_with_default("MAPID", MAPSAPI_MAPID)), "MapsAPI map id to use.")
+        ("num-downloads", po::value<int>()->value_name(name_with_default("NUM", maxConnections)),
          "Used to speed up downloads by allowing multiple concurrent downloads to happen at once.")
         ;
 
@@ -131,20 +125,20 @@ OpenSkyNetArgs::OpenSkyNetArgs() :
     });
 
     outputOptions_.add_options()
-        ("format", po::value<string>()->default_value("shp")->value_name("FORMAT")->notifier(formatNotifier),
+        ("format", po::value<string>()->value_name(name_with_default("FORMAT", outputFormat))->notifier(formatNotifier),
          outputDescription.c_str())
         ("output", po::value<string>()->value_name("PATH"),
          "Output location with file name and path or URL.")
-        ("output-layer", po::value<string>()->value_name(NameWithDefault("NAME", "skynetdetects")),
+        ("output-layer", po::value<string>()->value_name(name_with_default("NAME", "skynetdetects")),
          "The output layer name, index name, or table name.")
-        ("type", po::value<string>()->default_value("polygon")->value_name("TYPE"),
+        ("type", po::value<string>()->value_name(name_with_default("TYPE", "polygon")),
          "Output geometry type.  Currently only point and polygon are valid.")
         ("producer-info", "Add user name, application name, and application version to the output feature set.")
         ;
 
     processingOptions_.add_options()
         ("cpu", "Use the CPU for processing, the default it to use the GPU.")
-        ("max-utilization", po::value<float>()->default_value(maxUtitilization)->value_name("PERCENT"),
+        ("max-utilization", po::value<float>()->value_name(name_with_default("PERCENT", maxUtitilization)),
          "Maximum GPU utilization %. Minimum is 5, and maximum is 100. Not used if processing on CPU")
         ("model", po::value<string>()->value_name("PATH"), "Path to the the trained model.")
         ("window-size", po::cvSize_value()->min_tokens(1)->value_name("WIDTH [HEIGHT]"),
@@ -153,7 +147,7 @@ OpenSkyNetArgs::OpenSkyNetArgs() :
         ;
 
     detectOptions_.add_options()
-        ("confidence", po::value<float>()->value_name(NameWithDefault("PERCENT", confidence)),
+        ("confidence", po::value<float>()->value_name(name_with_default("PERCENT", confidence)),
          "Minimum percent score for results to be included in the output.")
         ("step-size", po::cvPoint_value()->min_tokens(1)->value_name("WIDTH [HEIGHT]"),
          "Sliding window step size. Default value is log2 of the model window size. Step size can be specified in "
@@ -161,7 +155,7 @@ OpenSkyNetArgs::OpenSkyNetArgs() :
         ("pyramid",
          "Use pyramids in feature detection. WARNING: This will result in much longer run times, but may result "
              "in additional features being detected.")
-        ("nms", po::bounded_value<std::vector<float>>()->min_tokens(0)->max_tokens(1)->value_name(NameWithDefault("PERCENT", overlap)),
+        ("nms", po::bounded_value<std::vector<float>>()->min_tokens(0)->max_tokens(1)->value_name(name_with_default("PERCENT", overlap)),
          "Perform non-maximum suppression on the output. You can optionally specify the overlap threshold percentage "
          "for non-maximum suppression calculation.")
          ("include-labels", po::value<std::vector<string>>()->multitoken()->value_name("LABEL [LABEL...]"),

--- a/src/OpenSkyNetArgs.h
+++ b/src/OpenSkyNetArgs.h
@@ -69,8 +69,8 @@ public:
     std::string mapId = MAPSAPI_MAPID;
 
     // Output options
-    deepcore::vector::GeometryType geometryType = deepcore::vector::GeometryType::UNKNOWN;
-    std::string outputFormat;
+    deepcore::vector::GeometryType geometryType = deepcore::vector::GeometryType::POLYGON;
+    std::string outputFormat = "shp";
     std::string outputPath;
     std::string layerName;
     bool producerInfo = false;


### PR DESCRIPTION
Remove po::default_value and replace wth po::value_name(NameWithDefault(...)).  Unused variable warnings were being fired with default inputs, where the user didn't say anything.
