### PR TITLE
Use a default and simplify configure_file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,8 @@ else()
 endif()
 
 # Initialize version.h
-configure_file(src/version.h.in OpenSpaceNetVersion.h)
-
-# Set up include directory for local builds
-include_directories(${PROJECT_BINARY_DIR})
+configure_file(src/version.h.in include/OpenSpaceNetVersion.h)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
 
 find_package(DeepCore REQUIRED)


### PR DESCRIPTION
Updates so that the generated headers and copied ones are consistent with other projects:

 - All generated headers are placed in `include` (which is relative to `${CMAKE_CURRENT_BINARY_DIR`)
 - There was no change: Projects which have generated private headers should add `${CMAKE_CURRENT_BINARY_DIR}/include` to the path.