### PR TITLE
Bugfix, default window size and step only use model parameters

### DIFF
--- a/common/include/OpenSpaceNet.h
+++ b/common/include/OpenSpaceNet.h
@@ -59,8 +59,6 @@ private:
     void printModel();
     void skipLine() const;
     deepcore::imagery::SizeSteps calcWindows() const;
-    cv::Size calcPrimaryWindowSize() const;
-    cv::Point calcPrimaryWindowStep() const;
 
     OpenSpaceNetArgs args_;
     std::shared_ptr<deepcore::network::HttpCleanup> cleanup_;
@@ -74,8 +72,8 @@ private:
     std::unique_ptr<deepcore::geometry::Transformation> pixelToLL_;
 
     std::unique_ptr<deepcore::classification::ModelMetadata> metadata_;
-    cv::Size modelSize_;
-    cv::Point defaultStep_;
+    cv::Size primaryWindowSize_;
+    cv::Point primaryWindowStep_;
     float modelAspectRatio_;
 };
 

--- a/common/src/OpenSpaceNet.cpp
+++ b/common/src/OpenSpaceNet.cpp
@@ -127,8 +127,6 @@ void OpenSpaceNet::process()
 
     auto subsetWithBorder = SubsetWithBorder::create("border");
     if(args_.resampledSize) {
-        auto modelSize = metadata_->modelSize();
-        auto resampledSize = args_.resampledSize.get();
         subsetWithBorder->attr("paddedSize") = metadata_->modelSize();
     }
     subsetWithBorder->connectAttrs(*blockSource);

--- a/common/src/OpenSpaceNet.cpp
+++ b/common/src/OpenSpaceNet.cpp
@@ -493,7 +493,7 @@ Detector::Ptr OpenSpaceNet::initDetector()
 void OpenSpaceNet::initSegmentation(Model::Ptr model)
 {
     auto segmentation = std::dynamic_pointer_cast<Segmentation>(model);
-    DG_CHECK(segmentation, "Unsupported model type.");
+    DG_CHECK(segmentation, "Unsupported model type");
 
     segmentation->setRasterToPolygon(make_unique<RasterToPolygonDP>(args_.method, args_.epsilon, args_.minArea));
 }

--- a/common/src/OpenSpaceNet.cpp
+++ b/common/src/OpenSpaceNet.cpp
@@ -451,10 +451,10 @@ Detector::Ptr OpenSpaceNet::initDetector()
     modelAspectRatio_ = (float) metadata_->modelSize().height / metadata_->modelSize().width;
     float confidence = args_.confidence / 100;
 
-    if(!args_.windowStep.empty()) {
-        primaryWindowStep_ = { args_.windowStep[0], (int) roundf(modelAspectRatio_ * args_.windowStep[0]) };
+    if(!args_.windowSize.empty()) {
+        primaryWindowSize_ = { args_.windowSize[0], (int) roundf(modelAspectRatio_ * args_.windowSize[0]) };
     } else if (args_.resampledSize) {
-        primaryWindowStep_ = { *args_.resampledSize, (int) roundf(modelAspectRatio_ * (*args_.resampledSize)) };
+        primaryWindowSize_ = { *args_.resampledSize, (int) roundf(modelAspectRatio_ * (*args_.resampledSize)) };
     } else {
         primaryWindowSize_ = metadata_->modelSize();
     }


### PR DESCRIPTION
Updates to calculate 
 - primary step based on `--resampled-size` and `--window-size` in addition to `--window-step`.
 - primary size based on `--resampled-size` in addition to `--window-step`.

This requires changes in https://github.com/DigitalGlobe/GGD-DeepCore-Dev/pull/717